### PR TITLE
Add AI image gallery and expand manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This repository contains a simple static website dedicated to the Opel Astra H. It includes:
 
-- **Home page** with introductory video
-- **Parts catalog** with search functionality
-- **User manual** with maintenance tips
-- **Fan page** where visitors can share short messages
+ - **Home page** with introductory video and illustrated gallery
+ - **Parts catalog** with search functionality
+ - **User manual** with maintenance tips and advanced features
+ - **Fan page** where visitors can share short messages
 
 To view the site, open `index.html` in your browser. No build step is required.

--- a/assets/images/astra_car.svg
+++ b/assets/images/astra_car.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="150" viewBox="0 0 300 150">
+  <rect x="20" y="60" width="260" height="40" fill="#003580"/>
+  <rect x="70" y="30" width="160" height="40" fill="#0050a0"/>
+  <circle cx="90" cy="110" r="15" fill="#222"/>
+  <circle cx="210" cy="110" r="15" fill="#222"/>
+</svg>

--- a/assets/images/engine.svg
+++ b/assets/images/engine.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="150" viewBox="0 0 300 150">
+  <rect x="0" y="0" width="300" height="150" fill="#f8f8f8"/>
+  <rect x="70" y="40" width="160" height="70" rx="15" fill="#666"/>
+  <circle cx="120" cy="75" r="20" fill="#999"/>
+  <circle cx="180" cy="75" r="20" fill="#999"/>
+</svg>

--- a/assets/images/gear.svg
+++ b/assets/images/gear.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="150" viewBox="0 0 300 150">
+  <rect x="0" y="0" width="300" height="150" fill="#fff"/>
+  <circle cx="150" cy="75" r="30" fill="#333"/>
+  <path d="M150 35 L160 55 L190 55 L170 75 L190 95 L160 95 L150 115 L140 95 L110 95 L130 75 L110 55 L140 55 Z" fill="#666"/>
+</svg>

--- a/assets/images/interior.svg
+++ b/assets/images/interior.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="150" viewBox="0 0 300 150">
+  <rect x="0" y="0" width="300" height="150" fill="#eeeeee"/>
+  <rect x="50" y="40" width="200" height="70" rx="10" fill="#333"/>
+  <circle cx="100" cy="75" r="20" fill="#555"/>
+  <rect x="150" y="55" width="80" height="40" fill="#777"/>
+</svg>

--- a/assets/images/wheel.svg
+++ b/assets/images/wheel.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="150" viewBox="0 0 300 150">
+  <rect x="0" y="0" width="300" height="150" fill="#f0f0f0"/>
+  <circle cx="150" cy="75" r="40" fill="#444"/>
+  <circle cx="150" cy="75" r="20" fill="#888"/>
+</svg>

--- a/assets/style.css
+++ b/assets/style.css
@@ -41,3 +41,30 @@ section {
     padding: 10px;
     list-style: none;
 }
+
+/* Gallery styling */
+.gallery {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.gallery img {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    transition: transform 0.3s;
+    animation: slideIn 0.5s ease forwards;
+}
+
+.gallery img:hover {
+    transform: scale(1.05);
+}
+
+@keyframes slideIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+}

--- a/catalog.html
+++ b/catalog.html
@@ -25,6 +25,16 @@
         <li data-name="Timing Belt">Timing Belt Kit - recommended every 60k miles</li>
         <li data-name="Spark Plugs">Spark Plugs - set of 4 for petrol engines</li>
         <li data-name="Headlight Bulb">Headlight Bulb H7 - 55W</li>
+        <li data-name="Air Filter">Air Filter - OE replacement</li>
+        <li data-name="Fuel Filter">Fuel Filter - diesel and petrol variants</li>
+        <li data-name="Clutch Kit">Clutch Kit - includes pressure plate</li>
+        <li data-name="Wheel Bearing">Wheel Bearing - front hub assembly</li>
+        <li data-name="Radiator">Radiator - compatible with manual transmission</li>
+        <li data-name="Turbocharger">Turbocharger - upgrade kit</li>
+        <li data-name="Rear Spoiler">Rear Spoiler - sport style</li>
+        <li data-name="Performance Exhaust">Performance Exhaust - stainless steel</li>
+        <li data-name="Sport Seats">Sport Seats - pair with side bolsters</li>
+        <li data-name="LED Headlights">LED Headlights - bright white</li>
     </ul>
 </section>
 </body>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,13 @@
     <h2>Welcome</h2>
     <p>The Opel Astra H is a beloved compact car known for its reliability and sporty handling. This site contains resources for owners and fans alike.</p>
     <iframe width="640" height="360" src="https://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe>
+    <div class="gallery">
+        <img src="assets/images/astra_car.svg" alt="Stylized Astra H" />
+        <img src="assets/images/interior.svg" alt="Cabin illustration" />
+        <img src="assets/images/engine.svg" alt="Engine block" />
+        <img src="assets/images/wheel.svg" alt="Wheel design" />
+        <img src="assets/images/gear.svg" alt="Gear mechanism" />
+    </div>
 </section>
 </body>
 </html>

--- a/manual.html
+++ b/manual.html
@@ -26,6 +26,19 @@
         <li>Inspect brake pads for wear.</li>
         <li>Follow recommended service intervals.</li>
     </ul>
+    <h3>Safety Features</h3>
+    <p>Modern Astra H models include airbags, ABS, and stability control systems designed to protect occupants.</p>
+    <h3>Troubleshooting Basics</h3>
+    <p>For warning lights or unusual noises, consult a qualified mechanic or reference the official repair guide.</p>
+    <h3>Advanced Features</h3>
+    <ul>
+        <li>On-board diagnostics accessible via the OBD-II port.</li>
+        <li>Optional cruise control for long highway drives.</li>
+        <li>Infotainment upgrades with Bluetooth connectivity.</li>
+    </ul>
+    <h3>Customization Ideas</h3>
+    <p>Enhance your Astra with alloy wheels, sport suspension, or custom interior trim to personalize your ride.</p>
+    <img src="assets/images/engine.svg" alt="Manual diagram" />
 </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace placeholder images with simple SVG illustrations
- animate gallery images with CSS
- extend parts catalog with more items
- add advanced features and customization tips to manual
- update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840525ccdd48325ba9d46e2efce3ed1